### PR TITLE
client: add UidCopyWithData to expose UIDPLUS COPYUID

### DIFF
--- a/client/cmd_selected.go
+++ b/client/cmd_selected.go
@@ -362,10 +362,19 @@ func parseCopyData(status *imap.StatusResp) (*CopyData, error) {
 	}, nil
 }
 
+// maxCopyUIDs bounds how many UIDs parseUIDList will materialize from a single
+// COPYUID set. COPYUID is parsed from untrusted server data, where a uid-range
+// such as "1:4294967295" would otherwise expand to a multi-gigabyte slice. A
+// legitimate COPYUID never approaches this — it carries one UID per message
+// copied by a single command.
+const maxCopyUIDs = 1 << 20
+
 // parseUIDList expands a COPYUID uid-set (RFC 4315) into UIDs in the order the
 // server listed them, so the source and destination lists stay positionally
-// aligned. Unlike imap.ParseSeqSet it neither sorts nor coalesces, and it
-// rejects the "*" wildcard since COPYUID always reports concrete UIDs.
+// aligned. Unlike imap.ParseSeqSet it neither sorts nor coalesces. It rejects
+// the "*" wildcard and a UID of 0 (UIDs are nz-number), and caps the total
+// number of expanded UIDs at maxCopyUIDs so a malformed range can't exhaust
+// memory.
 func parseUIDList(set string) ([]uint32, error) {
 	if set == "" {
 		return nil, fmt.Errorf("empty uid set")
@@ -375,23 +384,36 @@ func parseUIDList(set string) ([]uint32, error) {
 	for _, part := range strings.Split(set, ",") {
 		lo, hi, isRange := strings.Cut(part, ":")
 
-		start, err := strconv.ParseUint(lo, 10, 32)
+		start, err := parseUID(lo)
 		if err != nil {
-			return nil, fmt.Errorf("invalid uid %q: %w", lo, err)
+			return nil, err
 		}
 		if !isRange {
-			uids = append(uids, uint32(start))
+			if len(uids)+1 > maxCopyUIDs {
+				return nil, fmt.Errorf("uid set exceeds %d entries", maxCopyUIDs)
+			}
+			uids = append(uids, start)
 			continue
 		}
 
-		stop, err := strconv.ParseUint(hi, 10, 32)
+		stop, err := parseUID(hi)
 		if err != nil {
-			return nil, fmt.Errorf("invalid uid %q: %w", hi, err)
+			return nil, err
 		}
+
+		// Reject oversized ranges before allocating anything.
+		span := uint64(stop) - uint64(start)
+		if start > stop {
+			span = uint64(start) - uint64(stop)
+		}
+		if uint64(len(uids))+span+1 > maxCopyUIDs {
+			return nil, fmt.Errorf("uid set exceeds %d entries", maxCopyUIDs)
+		}
+
 		// Ranges may be given ascending or descending; expand in the listed
 		// direction. The break-on-equal form avoids uint overflow at the bounds.
 		for u := start; ; {
-			uids = append(uids, uint32(u))
+			uids = append(uids, u)
 			if u == stop {
 				break
 			}
@@ -403,6 +425,19 @@ func parseUIDList(set string) ([]uint32, error) {
 		}
 	}
 	return uids, nil
+}
+
+// parseUID parses a single COPYUID UID atom. UIDs are nz-number (RFC 3501), so 0
+// is rejected.
+func parseUID(s string) (uint32, error) {
+	n, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		return 0, fmt.Errorf("invalid uid %q: %w", s, err)
+	}
+	if n == 0 {
+		return 0, fmt.Errorf("invalid uid 0")
+	}
+	return uint32(n), nil
 }
 
 func (c *Client) move(uid bool, seqset *imap.SeqSet, dest string) error {

--- a/client/cmd_selected.go
+++ b/client/cmd_selected.go
@@ -292,12 +292,13 @@ type CopyData struct {
 }
 
 // UidCopyWithData is identical to UidCopy, but additionally returns the COPYUID
-// data (RFC 4315) when the server includes a COPYUID response code (which
-// UIDPLUS-capable servers send on a successful copy). This lets callers learn
-// the destination UID of a copied message directly, instead of searching for it
-// afterward. When the response carries no COPYUID code, the returned *CopyData
-// is nil and err is nil; callers should then locate the copied messages by
-// other means.
+// data when the server includes a COPYUID response code. RFC 4315 section 3
+// recommends that servers return COPYUID even when they don't advertise the
+// UIDPLUS capability, so this keys off the presence of the response code rather
+// than a capability check. This lets callers learn the destination UID of a
+// copied message directly, instead of searching for it afterward. When the
+// response carries no COPYUID code, the returned *CopyData is nil and err is
+// nil; callers should then locate the copied messages by other means.
 func (c *Client) UidCopyWithData(seqset *imap.SeqSet, dest string) (*CopyData, error) {
 	if c.State() != imap.SelectedState {
 		return nil, ErrNoMailboxSelected

--- a/client/cmd_selected.go
+++ b/client/cmd_selected.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"errors"
+	"fmt"
+	"strconv"
 
 	"github.com/emersion/go-imap"
 	"github.com/emersion/go-imap/commands"
@@ -275,6 +277,82 @@ func (c *Client) Copy(seqset *imap.SeqSet, dest string) error {
 // identifiers instead of message sequence numbers.
 func (c *Client) UidCopy(seqset *imap.SeqSet, dest string) error {
 	return c.copy(true, seqset, dest)
+}
+
+// CopyData holds the COPYUID data from the UIDPLUS extension (RFC 4315),
+// reporting the UIDs assigned to the copied messages in the destination
+// mailbox. DestUIDs corresponds positionally to SourceUIDs.
+type CopyData struct {
+	UIDValidity uint32
+	SourceUIDs  *imap.SeqSet
+	DestUIDs    *imap.SeqSet
+}
+
+// UidCopyWithData is identical to UidCopy, but additionally returns the COPYUID
+// data (RFC 4315) when the server advertises UIDPLUS. This lets callers learn
+// the destination UID of a copied message directly, instead of searching for it
+// afterward. When the server does not return a COPYUID code, the returned
+// *CopyData is nil and err is nil; callers should then locate the copied
+// messages by other means.
+func (c *Client) UidCopyWithData(seqset *imap.SeqSet, dest string) (*CopyData, error) {
+	if c.State() != imap.SelectedState {
+		return nil, ErrNoMailboxSelected
+	}
+
+	cmd := &commands.Uid{Cmd: &commands.Copy{
+		SeqSet:  seqset,
+		Mailbox: dest,
+	}}
+
+	status, err := c.execute(cmd, nil)
+	if err != nil {
+		return nil, err
+	}
+	if err := status.Err(); err != nil {
+		return nil, err
+	}
+
+	return parseCopyData(status)
+}
+
+// parseCopyData extracts UIDPLUS COPYUID data from a command's status response.
+// It returns (nil, nil) when the response carries no COPYUID code, which is the
+// case for servers that don't support UIDPLUS.
+func parseCopyData(status *imap.StatusResp) (*CopyData, error) {
+	if status == nil || status.Code != imap.CodeCopyUid {
+		return nil, nil
+	}
+	if len(status.Arguments) != 3 {
+		return nil, fmt.Errorf("imap: malformed COPYUID response code: expected 3 arguments, got %d", len(status.Arguments))
+	}
+
+	args := make([]string, len(status.Arguments))
+	for i, a := range status.Arguments {
+		s, ok := a.(string)
+		if !ok {
+			return nil, fmt.Errorf("imap: malformed COPYUID argument %d: expected string, got %T", i, a)
+		}
+		args[i] = s
+	}
+
+	uidValidity, err := strconv.ParseUint(args[0], 10, 32)
+	if err != nil {
+		return nil, fmt.Errorf("imap: invalid COPYUID uidvalidity %q: %w", args[0], err)
+	}
+	sourceUIDs, err := imap.ParseSeqSet(args[1])
+	if err != nil {
+		return nil, fmt.Errorf("imap: invalid COPYUID source set %q: %w", args[1], err)
+	}
+	destUIDs, err := imap.ParseSeqSet(args[2])
+	if err != nil {
+		return nil, fmt.Errorf("imap: invalid COPYUID destination set %q: %w", args[2], err)
+	}
+
+	return &CopyData{
+		UIDValidity: uint32(uidValidity),
+		SourceUIDs:  sourceUIDs,
+		DestUIDs:    destUIDs,
+	}, nil
 }
 
 func (c *Client) move(uid bool, seqset *imap.SeqSet, dest string) error {

--- a/client/cmd_selected.go
+++ b/client/cmd_selected.go
@@ -343,6 +343,9 @@ func parseCopyData(status *imap.StatusResp) (*CopyData, error) {
 	if err != nil {
 		return nil, fmt.Errorf("imap: invalid COPYUID uidvalidity %q: %w", args[0], err)
 	}
+	if uidValidity == 0 {
+		return nil, fmt.Errorf("imap: invalid COPYUID uidvalidity 0")
+	}
 	sourceUIDs, err := parseUIDList(args[1])
 	if err != nil {
 		return nil, fmt.Errorf("imap: invalid COPYUID source set %q: %w", args[1], err)

--- a/client/cmd_selected.go
+++ b/client/cmd_selected.go
@@ -386,7 +386,12 @@ func parseUIDList(set string) ([]uint32, error) {
 
 	var uids []uint32
 	for _, part := range strings.Split(set, ",") {
-		lo, hi, isRange := strings.Cut(part, ":")
+		// strings.Cut would be cleaner but is Go 1.18+; this module targets go 1.13.
+		lo, hi := part, ""
+		isRange := false
+		if idx := strings.IndexByte(part, ':'); idx >= 0 {
+			lo, hi, isRange = part[:idx], part[idx+1:], true
+		}
 
 		start, err := parseUID(lo)
 		if err != nil {

--- a/client/cmd_selected.go
+++ b/client/cmd_selected.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/emersion/go-imap"
 	"github.com/emersion/go-imap/commands"
@@ -279,16 +280,15 @@ func (c *Client) UidCopy(seqset *imap.SeqSet, dest string) error {
 	return c.copy(true, seqset, dest)
 }
 
-// CopyData holds the COPYUID data from the UIDPLUS extension (RFC 4315),
-// reporting the source and destination UID sets from the server's COPYUID
-// response code. While RFC 4315 defines the two sets as positionally
-// corresponding on the wire, that pairing is not recoverable here: ParseSeqSet
-// sorts and coalesces ranges. For a single-message copy each set holds one UID,
-// so DestUIDs unambiguously gives the message's new UID.
+// CopyData holds the COPYUID data from the UIDPLUS extension (RFC 4315). The
+// message at SourceUIDs[i] in the source mailbox was copied to DestUIDs[i] in
+// the destination mailbox; the two slices are parallel and preserve the order
+// of the server's COPYUID response, so the positional mapping defined by
+// RFC 4315 is retained (unlike ParseSeqSet, which sorts and coalesces).
 type CopyData struct {
 	UIDValidity uint32
-	SourceUIDs  *imap.SeqSet
-	DestUIDs    *imap.SeqSet
+	SourceUIDs  []uint32
+	DestUIDs    []uint32
 }
 
 // UidCopyWithData is identical to UidCopy, but additionally returns the COPYUID
@@ -343,13 +343,16 @@ func parseCopyData(status *imap.StatusResp) (*CopyData, error) {
 	if err != nil {
 		return nil, fmt.Errorf("imap: invalid COPYUID uidvalidity %q: %w", args[0], err)
 	}
-	sourceUIDs, err := imap.ParseSeqSet(args[1])
+	sourceUIDs, err := parseUIDList(args[1])
 	if err != nil {
 		return nil, fmt.Errorf("imap: invalid COPYUID source set %q: %w", args[1], err)
 	}
-	destUIDs, err := imap.ParseSeqSet(args[2])
+	destUIDs, err := parseUIDList(args[2])
 	if err != nil {
 		return nil, fmt.Errorf("imap: invalid COPYUID destination set %q: %w", args[2], err)
+	}
+	if len(sourceUIDs) != len(destUIDs) {
+		return nil, fmt.Errorf("imap: COPYUID source/destination set size mismatch: %d source vs %d destination UIDs", len(sourceUIDs), len(destUIDs))
 	}
 
 	return &CopyData{
@@ -357,6 +360,49 @@ func parseCopyData(status *imap.StatusResp) (*CopyData, error) {
 		SourceUIDs:  sourceUIDs,
 		DestUIDs:    destUIDs,
 	}, nil
+}
+
+// parseUIDList expands a COPYUID uid-set (RFC 4315) into UIDs in the order the
+// server listed them, so the source and destination lists stay positionally
+// aligned. Unlike imap.ParseSeqSet it neither sorts nor coalesces, and it
+// rejects the "*" wildcard since COPYUID always reports concrete UIDs.
+func parseUIDList(set string) ([]uint32, error) {
+	if set == "" {
+		return nil, fmt.Errorf("empty uid set")
+	}
+
+	var uids []uint32
+	for _, part := range strings.Split(set, ",") {
+		lo, hi, isRange := strings.Cut(part, ":")
+
+		start, err := strconv.ParseUint(lo, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid uid %q: %w", lo, err)
+		}
+		if !isRange {
+			uids = append(uids, uint32(start))
+			continue
+		}
+
+		stop, err := strconv.ParseUint(hi, 10, 32)
+		if err != nil {
+			return nil, fmt.Errorf("invalid uid %q: %w", hi, err)
+		}
+		// Ranges may be given ascending or descending; expand in the listed
+		// direction. The break-on-equal form avoids uint overflow at the bounds.
+		for u := start; ; {
+			uids = append(uids, uint32(u))
+			if u == stop {
+				break
+			}
+			if start <= stop {
+				u++
+			} else {
+				u--
+			}
+		}
+	}
+	return uids, nil
 }
 
 func (c *Client) move(uid bool, seqset *imap.SeqSet, dest string) error {

--- a/client/cmd_selected.go
+++ b/client/cmd_selected.go
@@ -280,8 +280,11 @@ func (c *Client) UidCopy(seqset *imap.SeqSet, dest string) error {
 }
 
 // CopyData holds the COPYUID data from the UIDPLUS extension (RFC 4315),
-// reporting the UIDs assigned to the copied messages in the destination
-// mailbox. DestUIDs corresponds positionally to SourceUIDs.
+// reporting the source and destination UID sets from the server's COPYUID
+// response code. While RFC 4315 defines the two sets as positionally
+// corresponding on the wire, that pairing is not recoverable here: ParseSeqSet
+// sorts and coalesces ranges. For a single-message copy each set holds one UID,
+// so DestUIDs unambiguously gives the message's new UID.
 type CopyData struct {
 	UIDValidity uint32
 	SourceUIDs  *imap.SeqSet
@@ -289,11 +292,12 @@ type CopyData struct {
 }
 
 // UidCopyWithData is identical to UidCopy, but additionally returns the COPYUID
-// data (RFC 4315) when the server advertises UIDPLUS. This lets callers learn
+// data (RFC 4315) when the server includes a COPYUID response code (which
+// UIDPLUS-capable servers send on a successful copy). This lets callers learn
 // the destination UID of a copied message directly, instead of searching for it
-// afterward. When the server does not return a COPYUID code, the returned
-// *CopyData is nil and err is nil; callers should then locate the copied
-// messages by other means.
+// afterward. When the response carries no COPYUID code, the returned *CopyData
+// is nil and err is nil; callers should then locate the copied messages by
+// other means.
 func (c *Client) UidCopyWithData(seqset *imap.SeqSet, dest string) (*CopyData, error) {
 	if c.State() != imap.SelectedState {
 		return nil, ErrNoMailboxSelected

--- a/client/cmd_selected_test.go
+++ b/client/cmd_selected_test.go
@@ -948,6 +948,23 @@ func Test_parseCopyData(t *testing.T) {
 			status:  copyUid("1", "78", "42:*"),
 			wantErr: true,
 		},
+		{
+			name:    "uid 0 rejected",
+			status:  copyUid("1", "0", "42"),
+			wantErr: true,
+		},
+		{
+			name:    "empty set rejected",
+			status:  copyUid("1", "", "42"),
+			wantErr: true,
+		},
+		{
+			// A malicious/buggy server must not be able to make the client
+			// allocate a multi-gigabyte slice from a tiny response.
+			name:    "oversized range rejected",
+			status:  copyUid("1", "1:4294967295", "1:4294967295"),
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/client/cmd_selected_test.go
+++ b/client/cmd_selected_test.go
@@ -876,6 +876,86 @@ func TestClient_UidCopyWithData(t *testing.T) {
 	}
 }
 
+func Test_parseCopyData(t *testing.T) {
+	mustSeqSet := func(set string) *imap.SeqSet {
+		s, err := imap.ParseSeqSet(set)
+		if err != nil {
+			t.Fatalf("ParseSeqSet(%q): %v", set, err)
+		}
+		return s
+	}
+
+	copyUid := func(args ...interface{}) *imap.StatusResp {
+		return &imap.StatusResp{Type: imap.StatusRespOk, Code: imap.CodeCopyUid, Arguments: args}
+	}
+
+	tests := []struct {
+		name    string
+		status  *imap.StatusResp
+		want    *CopyData
+		wantErr bool
+	}{
+		{
+			name:   "nil status",
+			status: nil,
+			want:   nil,
+		},
+		{
+			name:   "no copyuid code",
+			status: &imap.StatusResp{Type: imap.StatusRespOk},
+			want:   nil,
+		},
+		{
+			name:   "valid",
+			status: copyUid("1234567890", "78", "42"),
+			want:   &CopyData{UIDValidity: 1234567890, SourceUIDs: mustSeqSet("78"), DestUIDs: mustSeqSet("42")},
+		},
+		{
+			name:    "wrong argument count",
+			status:  copyUid("1234567890", "78"),
+			wantErr: true,
+		},
+		{
+			name:    "non-string argument",
+			status:  copyUid("1234567890", 78, "42"),
+			wantErr: true,
+		},
+		{
+			name:    "non-numeric uidvalidity",
+			status:  copyUid("abc", "78", "42"),
+			wantErr: true,
+		},
+		{
+			name:    "unparseable source set",
+			status:  copyUid("1", "x", "42"),
+			wantErr: true,
+		},
+		{
+			name:    "unparseable dest set",
+			status:  copyUid("1", "78", "4:x"),
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCopyData(tt.status)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("parseCopyData() expected an error, got nil (data=%#v)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("parseCopyData() = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("parseCopyData() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestClient_Unselect(t *testing.T) {
 	c, s := newTestClient(t)
 	defer s.Close()

--- a/client/cmd_selected_test.go
+++ b/client/cmd_selected_test.go
@@ -789,14 +789,6 @@ func TestClient_Copy_Uid(t *testing.T) {
 }
 
 func TestClient_UidCopyWithData(t *testing.T) {
-	mustSeqSet := func(set string) *imap.SeqSet {
-		s, err := imap.ParseSeqSet(set)
-		if err != nil {
-			t.Fatalf("ParseSeqSet(%q): %v", set, err)
-		}
-		return s
-	}
-
 	tests := []struct {
 		name     string
 		response string // server response following the command tag and a space
@@ -808,23 +800,37 @@ func TestClient_UidCopyWithData(t *testing.T) {
 			response: "OK [COPYUID 1234567890 78 42] UID COPY completed\r\n",
 			wantData: &CopyData{
 				UIDValidity: 1234567890,
-				SourceUIDs:  mustSeqSet("78"),
-				DestUIDs:    mustSeqSet("42"),
+				SourceUIDs:  []uint32{78},
+				DestUIDs:    []uint32{42},
 			},
 		},
 		{
-			name:     "uidplus message range",
+			name:     "uidplus message range expands in order",
 			response: "OK [COPYUID 1234567890 78:80 42:44] UID COPY completed\r\n",
 			wantData: &CopyData{
 				UIDValidity: 1234567890,
-				SourceUIDs:  mustSeqSet("78:80"),
-				DestUIDs:    mustSeqSet("42:44"),
+				SourceUIDs:  []uint32{78, 79, 80},
+				DestUIDs:    []uint32{42, 43, 44},
+			},
+		},
+		{
+			name:     "uidplus discontiguous set preserves source-to-dest pairing",
+			response: "OK [COPYUID 1234567890 5,10:12,7 100,200:202,150] UID COPY completed\r\n",
+			wantData: &CopyData{
+				UIDValidity: 1234567890,
+				SourceUIDs:  []uint32{5, 10, 11, 12, 7},
+				DestUIDs:    []uint32{100, 200, 201, 202, 150},
 			},
 		},
 		{
 			name:     "server without uidplus",
 			response: "OK UID COPY completed\r\n",
 			wantData: nil,
+		},
+		{
+			name:     "copyuid source/dest size mismatch",
+			response: "OK [COPYUID 1234567890 78:80 42] UID COPY completed\r\n",
+			wantErr:  true,
 		},
 		{
 			name:     "server error",
@@ -877,14 +883,6 @@ func TestClient_UidCopyWithData(t *testing.T) {
 }
 
 func Test_parseCopyData(t *testing.T) {
-	mustSeqSet := func(set string) *imap.SeqSet {
-		s, err := imap.ParseSeqSet(set)
-		if err != nil {
-			t.Fatalf("ParseSeqSet(%q): %v", set, err)
-		}
-		return s
-	}
-
 	copyUid := func(args ...interface{}) *imap.StatusResp {
 		return &imap.StatusResp{Type: imap.StatusRespOk, Code: imap.CodeCopyUid, Arguments: args}
 	}
@@ -908,7 +906,12 @@ func Test_parseCopyData(t *testing.T) {
 		{
 			name:   "valid",
 			status: copyUid("1234567890", "78", "42"),
-			want:   &CopyData{UIDValidity: 1234567890, SourceUIDs: mustSeqSet("78"), DestUIDs: mustSeqSet("42")},
+			want:   &CopyData{UIDValidity: 1234567890, SourceUIDs: []uint32{78}, DestUIDs: []uint32{42}},
+		},
+		{
+			name:   "descending range expands in listed order",
+			status: copyUid("1", "80:78", "44:42"),
+			want:   &CopyData{UIDValidity: 1, SourceUIDs: []uint32{80, 79, 78}, DestUIDs: []uint32{44, 43, 42}},
 		},
 		{
 			name:    "wrong argument count",
@@ -933,6 +936,16 @@ func Test_parseCopyData(t *testing.T) {
 		{
 			name:    "unparseable dest set",
 			status:  copyUid("1", "78", "4:x"),
+			wantErr: true,
+		},
+		{
+			name:    "source/dest size mismatch",
+			status:  copyUid("1", "78:80", "42"),
+			wantErr: true,
+		},
+		{
+			name:    "wildcard rejected",
+			status:  copyUid("1", "78", "42:*"),
 			wantErr: true,
 		},
 	}

--- a/client/cmd_selected_test.go
+++ b/client/cmd_selected_test.go
@@ -965,6 +965,19 @@ func Test_parseCopyData(t *testing.T) {
 			status:  copyUid("1", "1:4294967295", "1:4294967295"),
 			wantErr: true,
 		},
+		{
+			// The cap is enforced against the running total, so it can't be
+			// bypassed by splitting an oversized set across comma-separated
+			// ranges each individually under the limit.
+			name:    "comma-separated ranges exceed cap",
+			status:  copyUid("1", "1:600000,1:600000", "1:600000,1:600000"),
+			wantErr: true,
+		},
+		{
+			name:    "uidvalidity 0 rejected",
+			status:  copyUid("0", "78", "42"),
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/client/cmd_selected_test.go
+++ b/client/cmd_selected_test.go
@@ -788,6 +788,94 @@ func TestClient_Copy_Uid(t *testing.T) {
 	}
 }
 
+func TestClient_UidCopyWithData(t *testing.T) {
+	mustSeqSet := func(set string) *imap.SeqSet {
+		s, err := imap.ParseSeqSet(set)
+		if err != nil {
+			t.Fatalf("ParseSeqSet(%q): %v", set, err)
+		}
+		return s
+	}
+
+	tests := []struct {
+		name     string
+		response string // server response following the command tag and a space
+		wantData *CopyData
+		wantErr  bool
+	}{
+		{
+			name:     "uidplus single message",
+			response: "OK [COPYUID 1234567890 78 42] UID COPY completed\r\n",
+			wantData: &CopyData{
+				UIDValidity: 1234567890,
+				SourceUIDs:  mustSeqSet("78"),
+				DestUIDs:    mustSeqSet("42"),
+			},
+		},
+		{
+			name:     "uidplus message range",
+			response: "OK [COPYUID 1234567890 78:80 42:44] UID COPY completed\r\n",
+			wantData: &CopyData{
+				UIDValidity: 1234567890,
+				SourceUIDs:  mustSeqSet("78:80"),
+				DestUIDs:    mustSeqSet("42:44"),
+			},
+		},
+		{
+			name:     "server without uidplus",
+			response: "OK UID COPY completed\r\n",
+			wantData: nil,
+		},
+		{
+			name:     "server error",
+			response: "NO [TRYCREATE] mailbox does not exist\r\n",
+			wantErr:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c, s := newTestClient(t)
+			defer s.Close()
+
+			setClientState(c, imap.SelectedState, nil)
+
+			seqset, _ := imap.ParseSeqSet("78")
+
+			type result struct {
+				data *CopyData
+				err  error
+			}
+			resCh := make(chan result, 1)
+			go func() {
+				data, err := c.UidCopyWithData(seqset, "Drafts")
+				resCh <- result{data, err}
+			}()
+
+			tag, cmd := s.ScanCmd()
+			if cmd != "UID COPY 78 \"Drafts\"" {
+				t.Fatalf("client sent command %v, want %v", cmd, "UID COPY 78 \"Drafts\"")
+			}
+
+			s.WriteString(tag + " " + tt.response)
+
+			res := <-resCh
+			if tt.wantErr {
+				if res.err == nil {
+					t.Fatalf("UidCopyWithData() expected an error, got nil")
+				}
+				return
+			}
+			if res.err != nil {
+				t.Fatalf("UidCopyWithData() = %v", res.err)
+			}
+			if !reflect.DeepEqual(res.data, tt.wantData) {
+				t.Errorf("CopyData = %#v, want %#v", res.data, tt.wantData)
+			}
+		})
+	}
+}
+
 func TestClient_Unselect(t *testing.T) {
 	c, s := newTestClient(t)
 	defer s.Close()

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/emersion/go-imap
 go 1.13
 
 require (
-	github.com/emersion/go-imap v1.2.1
 	github.com/emersion/go-message v0.15.0
 	github.com/emersion/go-sasl v0.0.0-20200509203442-7bfe0ed36a21
 	golang.org/x/text v0.3.7

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/emersion/go-imap v1.2.1 h1:+s9ZjMEjOB8NzZMVTM3cCenz2JrQIGGo5j1df19WjTA=
-github.com/emersion/go-imap v1.2.1/go.mod h1:Qlx1FSx2FTxjnjWpIlVNEuX+ylerZQNFE5NsmKFSejY=
 github.com/emersion/go-message v0.15.0 h1:urgKGqt2JAc9NFJcgncQcohHdiYb803YTH9OQwHBHIY=
 github.com/emersion/go-message v0.15.0/go.mod h1:wQUEfE+38+7EW8p8aZ96ptg6bAb1iwdgej19uXASlE4=
 github.com/emersion/go-sasl v0.0.0-20200509203442-7bfe0ed36a21 h1:OJyUGMJTzHTd1XQp98QTaHernxMYzRaOasRir9hUlFQ=

--- a/status.go
+++ b/status.go
@@ -55,7 +55,8 @@ const (
 	CodeUidValidity    StatusRespCode = "UIDVALIDITY"
 	CodeUnseen         StatusRespCode = "UNSEEN"
 	// CodeCopyUid is the COPYUID response code from the UIDPLUS extension
-	// (RFC 4315 section 3), returned on a successful COPY or MOVE.
+	// (RFC 4315 section 3). A server sends it on a successful UID COPY (and, per
+	// RFC 6851, MOVE). Only UidCopyWithData surfaces it today.
 	CodeCopyUid StatusRespCode = "COPYUID"
 )
 

--- a/status.go
+++ b/status.go
@@ -54,6 +54,9 @@ const (
 	CodeUidNext        StatusRespCode = "UIDNEXT"
 	CodeUidValidity    StatusRespCode = "UIDVALIDITY"
 	CodeUnseen         StatusRespCode = "UNSEEN"
+	// CodeCopyUid is the COPYUID response code from the UIDPLUS extension
+	// (RFC 4315 section 3), returned on a successful COPY or MOVE.
+	CodeCopyUid StatusRespCode = "COPYUID"
 )
 
 // A status response.


### PR DESCRIPTION
## Description

Adds `Client.UidCopyWithData`, which performs a `UID COPY` and returns the UIDPLUS `COPYUID` data (RFC 4315) — the UIDs the copied messages were assigned in the destination mailbox. Today `UidCopy` discards the command's status response, so destination UIDs are unrecoverable except by searching the destination folder afterward, which is fragile: it requires a Message-ID or a complete header set and can match zero or many messages.

Motivation: in go-mantis, IMAP move-to-spam (and other move-based remediations) recovers a moved message's new UID by searching the destination folder by header. When no Message-ID / complete fallback header is available, that search fails and a move that actually succeeded gets reported as a failure and retried. `COPYUID` returns the new UIDs directly from the copy, eliminating the search on UIDPLUS servers (and should also be covered on non-UIDPLUS servers that are following the spec).

## How did you validate this change
Added unit tests, researched and matched edge cases and response codes as best as I can determine. Nothing is using this code until it's implemented in `go-mantis`.

- Assisted by Claude 🤖